### PR TITLE
Fix extconf.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/ext/cbc-wrapper/Makefile
+/ext/cbc-wrapper/mkmf.log
+ext/cbc-wrapper/*.o
+ext/cbc-wrapper/*.so

--- a/ext/cbc-wrapper/cbc.i
+++ b/ext/cbc-wrapper/cbc.i
@@ -4,12 +4,12 @@
 %include "carrays.i"
 
 %{
-#include "Coin_C_defines.h"
-#include "Cbc_C_Interface.h"
+#include "coin/Coin_C_defines.h"
+#include "coin/Cbc_C_Interface.h"
 %}
 
 %array_class(int, IntArray)
 %array_class(double, DoubleArray)
 
-%include "Coin_C_defines.h"
-%include "Cbc_C_Interface.h"
+%include "coin/Coin_C_defines.h"
+%include "coin/Cbc_C_Interface.h"

--- a/ext/cbc-wrapper/cbc_wrap.c
+++ b/ext/cbc-wrapper/cbc_wrap.c
@@ -1851,8 +1851,8 @@ struct timeval rb_time_timeval(VALUE);
 #endif
 
 
-#include "Coin_C_defines.h"
-#include "Cbc_C_Interface.h"
+#include "coin/Coin_C_defines.h"
+#include "coin/Cbc_C_Interface.h"
 
 
 typedef int IntArray;

--- a/ext/cbc-wrapper/extconf.rb
+++ b/ext/cbc-wrapper/extconf.rb
@@ -1,10 +1,14 @@
 require 'mkmf'
-ROOT_DIR = File.dirname(File.absolute_path(__FILE__))
 
 ## Rerun this if updated cbc version
 #  swig_cmd = find_executable "swig"
 #  current_path = File.expand_path('../', __FILE__)
-#  %x{#{swig_cmd} -ruby -I#{current_path}/install/include/coin #{current_path}/cbc.i }
+#  %x{#{swig_cmd} -ruby -I#{current_path}/coin #{current_path}/cbc.i }
+
+dir_config('cbc-wrapper')
+dir_config('cbc')
+
+succeed = true
 
 libs = %w[
   Cbc
@@ -20,14 +24,21 @@ libs = %w[
 ]
 
 libs.each do |lib|
-  find_library(lib, nil)
+  unless find_library(lib, nil)
+    succeed = false
+  end
 end
 
-headers = Dir['coin/*.h'].map { |h| h.split('/').last }
+headers = ["coin/Cbc_C_Interface.h", "coin/Coin_C_defines.h"]
+
 headers.each do |header|
-  puts find_header(header, 'coin/')
+  unless find_header(header)
+    succeed = false
+  end
 end
 
-dir_config('cbc-wrapper')
-RPATHFLAG << " -Wl,-rpath,'$$ORIGIN/install/lib'"
-create_makefile('cbc_wrapper')
+if succeed
+  create_makefile('cbc_wrapper')
+else
+  abort "Missing some libraries or headers"
+end

--- a/ext/cbc-wrapper/extconf.rb
+++ b/ext/cbc-wrapper/extconf.rb
@@ -11,16 +11,7 @@ dir_config('cbc')
 succeed = true
 
 libs = %w[
-  Cbc
   CbcSolver
-  Cgl
-  Clp
-  ClpSolver
-  CoinUtils
-  Osi
-  OsiCbc
-  OsiClp
-  OsiCommonTests
 ]
 
 libs.each do |lib|

--- a/ext/cbc-wrapper/install/.gitignore
+++ b/ext/cbc-wrapper/install/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore


### PR DESCRIPTION
See https://github.com/gverger/cbc-wrapper/issues/2#issuecomment-425645135.

* Support for `--with-cbc-*` option for non-standard locations
* Link only `libCbcSolver` to avoid parameter parsing error message