### PR TITLE
Use `pkg-config` to find Cbc

### DIFF
--- a/ext/cbc-wrapper/extconf.rb
+++ b/ext/cbc-wrapper/extconf.rb
@@ -7,6 +7,7 @@ require 'mkmf'
 
 dir_config('cbc-wrapper')
 dir_config('cbc')
+pkg_config('cbc')
 
 succeed = true
 


### PR DESCRIPTION
Hi, and thanks for making this wrapper, it provides for a nice interface to create models!

I ran into the same issue as https://github.com/gverger/ruby-cbc/issues/27 while trying to install `ruby-cbc` using cbc from homebrew:
```
# checking for -lCbcSolver... no
# checking for coin/Cbc_C_Interface.h... yes
# checking for coin/Coin_C_defines.h... yes
# Missing some libraries or headers
```

By default `extconf.rb` doesn't know where to find cbc, so it needs to be passed manually for the installation to succeed, [see here](https://github.com/gverger/ruby-cbc/issues/27#issuecomment-2438788329).

This PR solves this by using `pkg-config` to automatically find the library when `pkg-config` is installed on the system.